### PR TITLE
repodata_record.sha256 is optional for conda lock files?

### DIFF
--- a/pixi_to_conda_lock.py
+++ b/pixi_to_conda_lock.py
@@ -94,11 +94,13 @@ def _create_conda_package_entry(
         "url": package.location,
         "hash": {
             "md5": repodata_record.md5.hex(),
-            "sha256": repodata_record.sha256.hex(),
         },
         "category": "main",
         "optional": False,
     }
+
+    if repodata_record.sha256:
+        package_entry["hash"]["sha256"] = repodata_record.sha256.hex()
 
     logging.debug(
         "Created conda package entry: %s v%s",


### PR DESCRIPTION
While converting a pixi lock file which has an old package which only has a md5 hash and no sha256 I was getting an error.

```
#     "sha256": repodata_record.sha256.hex(),
# AttributeError: 'NoneType' object has no attribute 'hex'
```

Looking into the [model specification](https://github.com/conda/conda-lock/blob/6aeaf80840afd602bf6e952c8f1f3cfac0e688c3/conda_lock/lockfile/v1/models.py#L66) of the lock file, it seems like SHA256 is optional? 