### PR TITLE
Fix ruff target-version to match requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ line_length = 88
 
 [tool.ruff]
 line-length = 100
-target-version = "py37"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
The ruff target-version was set to py37, but requires-python is >=3.9. This aligns them.