### PR TITLE
Add py.typed marker for PEP 561 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ pixi-to-conda-lock = "pixi_to_conda_lock:main"
 [tool.setuptools]
 py-modules = ["pixi_to_conda_lock"]
 
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
 [tool.pytest.ini_options]
 addopts = """
     --cov=pixi_to_conda_lock


### PR DESCRIPTION
Adds a py.typed marker file to signal that this package supports type checking, per PEP 561.