### PR TITLE
Fix SHA hash duplication in PyPI package URLs

### DIFF
--- a/pixi_to_conda_lock.py
+++ b/pixi_to_conda_lock.py
@@ -125,7 +125,7 @@ def _create_pypi_package_entry(
         "manager": "pip",
         "platform": str(platform),
         "dependencies": _list_of_str_dependencies_to_dict(package.requires_dist),
-        "url": package.location,
+        "url": str(package.location).split("#")[0],  # Strip hash fragment if present
         "hash": {"sha256": hashes.sha256.hex()},
         "category": "main",
         "optional": False,


### PR DESCRIPTION
## Summary
- Strip hash fragment from PyPI package URLs before storing in conda-lock.yml
- Some custom PyPI indexes (like PyTorch) include the hash in the URL fragment (`#sha256=...`)
- This caused conda-lock to concatenate it with the separate `hash` field, resulting in invalid/duplicated hashes

Fixes #4