### PR TITLE
Fix handling of PyPI packages with missing hash

### DIFF
--- a/pixi_to_conda_lock.py
+++ b/pixi_to_conda_lock.py
@@ -115,21 +115,23 @@ def _create_pypi_package_entry(
     platform: Platform,
 ) -> dict[str, Any]:
     """Create a conda-lock package entry from a PypiLockedPackage."""
-    hashes = package.hashes
-    if not hashes:  # pragma: no cover
-        msg = f"Package {package.name} has no hashes"
-        raise ValueError(msg)
-    return {
+    package_entry = {
         "name": package.name,
         "version": str(package.version),
         "manager": "pip",
         "platform": str(platform),
         "dependencies": _list_of_str_dependencies_to_dict(package.requires_dist),
         "url": str(package.location).split("#")[0],  # Strip hash fragment if present
-        "hash": {"sha256": hashes.sha256.hex()},
+        "hash": {},
         "category": "main",
         "optional": False,
     }
+    if package.hashes:
+        try:
+            package_entry["hash"] = {"sha256": package.hashes.sha256.hex()}
+        except AttributeError:
+            pass
+    return package_entry
 
 
 def _list_of_str_dependencies_to_dict(dependencies_list: list[str]) -> dict[str, str]:


### PR DESCRIPTION
Unfortunately, not all pypi packages provide their sha256 in the url. A prominent example is pytorch:

```
https://download.pytorch.org/whl/cu129/torch-2.9.1%2Bcu129-cp314-cp314-manylinux_2_28_x86_64.whl
```

We can get a test lock file from the following minimal pixi.toml:

```toml
[workspace]
channels = ["conda-forge"]
name = "test-pypi-no-hash"
version = "0.1.0"
platforms = [ "linux-64" ]

[target.linux-64.pypi-dependencies]
torch = { version = "*", index = "https://download.pytorch.org/whl/cu129" }

[dependencies]
python = "*"
pip = "*"
```

Current implementation fails with:

```python
Traceback (most recent call last):
  File "/Users/santi/.pixi/envs/pixi-to-conda-lock/lib/python3.14/site-packages/pixi_to_conda_lock.py", line 303, in main
    conda_lock_data = _convert_env_to_conda_lock(lock_file, env_name)
  File "/Users/santi/.pixi/envs/pixi-to-conda-lock/lib/python3.14/site-packages/pixi_to_conda_lock.py", line 213, in _convert_env_to_conda_lock
    pypi_package_entry = _create_pypi_package_entry(package, platform)
  File "/Users/santi/.pixi/envs/pixi-to-conda-lock/lib/python3.14/site-packages/pixi_to_conda_lock.py", line 129, in _create_pypi_package_entry
    "hash": {"sha256": hashes.sha256.hex()},
                       ^^^^^^^^^^^^^
  File "/Users/santi/.pixi/envs/pixi-to-conda-lock/lib/python3.14/site-packages/rattler/lock/hash.py", line 21, in sha256
    return self._hashes.sha256
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'sha256'
```

This PR attempts to fix this by providing an empty dictionary of hashes in this corner case - which seems to play well with conda-lock data model and produce valid environments.