### PR TITLE
Pin py-rattler minor version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pixi-to-conda-lock"
 description = "pixi-to-conda-lock converts a pixi.lock file to a conda-lock.yml file."
 dynamic = ["version"]
 authors = [{ name = "Bas Nijholt", email = "bas@nijho.lt" }]
-dependencies = ["pyyaml", "py-rattler"]
+dependencies = ["pyyaml", "py-rattler>=0.23.1,<0.24"]
 requires-python = ">=3.9"
 
 [project.readme]


### PR DESCRIPTION
## Summary
- Pin `py-rattler` to the current 0.23 minor series while allowing patch updates
- Prevent pre-1.0 minor releases from introducing breaking changes unexpectedly

Fixes #13

## Test Plan
- [x] `/tmp/pixi-to-conda-lock-verify.Zo0RlS/venv/bin/python -m pip install -e '.[test]'`
- [x] `git diff --check`\n- [x] `/tmp/pixi-to-conda-lock-verify.Zo0RlS/venv/bin/python -m pytest`