### PR TITLE
Fix pixi.lock v7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pixi-to-conda-lock"
 description = "pixi-to-conda-lock converts a pixi.lock file to a conda-lock.yml file."
 dynamic = ["version"]
 authors = [{ name = "Bas Nijholt", email = "bas@nijho.lt" }]
-dependencies = ["pyyaml", "py-rattler>=0.23.1,<0.24"]
+dependencies = ["pyyaml", "py-rattler>=0.24,<0.25"]
 requires-python = ">=3.9"
 
 [project.readme]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,6 +25,7 @@ from pixi_to_conda_lock import (
 
 TEST_DIR = Path(__file__).parent
 PIXI_LOCK_PATH = TEST_DIR / "test_data" / "pixi.lock"
+PIXI_LOCK_V7_PATH = TEST_DIR / "test_data" / "pixi-v7.lock"
 PIXI_LOCK_PYPI_PATH = TEST_DIR / "test_data" / "pixi-pypi.lock"
 
 
@@ -105,6 +106,15 @@ def test_convert_env_to_conda_lock_default(lock_file: LockFile) -> None:
     assert sorted(conda_lock_data["metadata"]["platforms"]) == ["osx-64", "osx-arm64"]
 
 
+def test_convert_env_to_conda_lock_pixi_lock_v7() -> None:
+    """Test _convert_env_to_conda_lock with a pixi.lock v7 fixture."""
+    lock_file = LockFile.from_path(PIXI_LOCK_V7_PATH)
+    conda_lock_data = _convert_env_to_conda_lock(lock_file, "default")
+    assert "package" in conda_lock_data
+    assert len(conda_lock_data["package"]) == 5  # noqa: PLR2004
+    assert sorted(conda_lock_data["metadata"]["platforms"]) == ["osx-64", "osx-arm64"]
+
+
 def test_main_integration(tmp_path: Path) -> None:
     """Integration test for main function."""
     output_dir = tmp_path / "output"
@@ -167,11 +177,21 @@ def test_main_exception(tmp_path: Path) -> None:
 def test_create_conda_package_entry(lock_file: LockFile) -> None:
     """Test the creation of conda package entries."""
     env = lock_file.environment("default")
-    platform = env.platforms()[0]
+    platform = next(
+        platform for platform in env.platforms() if str(platform) == "osx-64"
+    )
     conda_repodata = env.conda_repodata_records_for_platform(platform)
     assert conda_repodata is not None
     repo_mapping = {record.url: record for record in conda_repodata}
-    package = env.packages(platform)[0]
+    package = next(
+        (
+            package
+            for package in env.packages(platform)
+            if isinstance(package, CondaLockedPackage)
+            and repo_mapping[package.location].name.source == "bzip2"
+        ),
+        None,
+    )
     assert isinstance(package, CondaLockedPackage)
     result = _create_conda_package_entry(
         package,

--- a/tests/test_data/pixi-v7.lock
+++ b/tests/test_data/pixi-v7.lock
@@ -1,0 +1,88 @@
+# This file is derived from the v6 fixture to cover pixi.lock v7 parsing.
+
+version: 7
+platforms:
+- name: osx-64
+- name: osx-arm64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.13-5_cp313t.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.13-5_cp313t.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+  project1:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.13-5_cp313t.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.13-5_cp313t.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+  project2:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  arch: x86_64
+  platform: osx
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  arch: arm64
+  platform: osx
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.13-5_cp313t.conda
+  build_number: 5
+  sha256: a96553de64be6441400e88c2c6ad7123d91cbcea4898b5966a653163f30d9f55
+  md5: 32ba8fc57ccb0b48dd6006974f65c525
+  constrains:
+  - python 3.13.* *_cp313t
+  arch: x86_64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6300
+  timestamp: 1723823108577
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.13-5_cp313t.conda
+  build_number: 5
+  sha256: 2165466ff175e1890b66d079d64449a1b6dd9873fb0f5e977839ccc4639b813b
+  md5: 24a9a05eba65586da53ad7b56a06dc02
+  constrains:
+  - python 3.13.* *_cp313t
+  arch: arm64
+  platform: osx
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6317
+  timestamp: 1723823118660
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025a-h78e105d_0.conda
+  sha256: c4b1ae8a2931fe9b274c44af29c5475a85b37693999f8c792dad0f8c6734b1de
+  md5: dbcace4706afdfb7eb891f7b37d07c04
+  license: LicenseRef-Public-Domain
+  size: 122921
+  timestamp: 1737119101255


### PR DESCRIPTION
## Summary
- Bump the supported py-rattler minor series to 0.24 so pixi.lock v7 files parse.
- Add a minimal pixi.lock v7 regression fixture and conversion test.

Fixes #17

## Test Plan
- [x] uv run --no-sync pytest
- [x] uv run pre-commit run --all-files